### PR TITLE
added conditions to enhance  pip command parsing to support git urls

### DIFF
--- a/src/ersilia_pack/parsers.py
+++ b/src/ersilia_pack/parsers.py
@@ -47,8 +47,13 @@ class InstallParser:
         for command in commands:
             if type(command) is list:
                 if command[0] == "pip":
-                    assert len(command) == 3, "pip command must have 3 arguments"
-                    cmd = f"{python_exe} -m pip install " + command[1] + "==" + command[2]
+                    assert len(command) in (2, 3), "pip command must have 2 or 3 arguments"
+                    # for git url or wheel file/paths/url 
+                    if len(command) == 2: 
+                        if command[1].startswith("git+") or command[1].endswith(".whl"):
+                            cmd = f"{python_exe} -m pip install " + command[1]
+                    elif len(command) == 3:
+                            cmd = f"{python_exe} -m pip install " + command[1] + "==" + command[2]
                 elif command[0] == "conda":
                     assert len(command) == 4, "conda command must have 4 arguments"
                     if command[3] == "default":


### PR DESCRIPTION
### Description

This pull request imporoves the InstallParser class to improve the handling of pip dependencies . It specifically adds support for Git URLs and wheel files, addressing a limitation in handling such  edge cases in dependency installation 

### Changes to Be Made
Updated the command parsing logic to:

-  Accept two or three arguments for pip install commands.
-  Allow Git URLs without version specification.
-  Allow wheel files without additional arguments.

I implemented the assert to ensure the number of argument and maintained theerror handling.
Related to #21 