### PR TITLE
YAMLInstallParser Class Unit Test

### DIFF
--- a/tests/test_yaml_install_parser.py
+++ b/tests/test_yaml_install_parser.py
@@ -1,35 +1,38 @@
 import unittest
 from unittest.mock import patch, mock_open
 import yaml
-from src.ersilia_pack.parsers import YAMLInstallParser  # Correct import
+from src.ersilia_pack.parsers import YAMLInstallParser
 
 class TestYAMLInstallParser(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.safe_load")
+    # Test method for the python version
     def test_get_python_version(self, mock_yaml_safe_load, mock_file):
         mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
-        parser = YAMLInstallParser(file_dir="/some/directory")
+        parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
         python_version = parser._get_python_version()
         self.assertEqual(python_version, "3.9")
 
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("yaml.safe_load")
-    def test_get_python_version_raises_error(self, mock_yaml_safe_load, mock_file):
-        # Mock YAML data with an invalid non-string Python version
-        mock_yaml_safe_load.return_value = {"python": 3.9, "commands": ["cmd1", "cmd2"]}
-        parser = YAMLInstallParser(file_dir="/some/directory")
-        with self.assertRaises(ValueError) as context:
-            parser._get_python_version()
-        self.assertEqual(str(context.exception), "Python version must be a string")
 
+    @patch("builtins.open", new_callable=mock_open, read_data="python: 3.9\ncommands:\n  - cmd1\n  - cmd2")
+    @patch("yaml.safe_load", return_value={"python": 3.9, "commands": ["cmd1", "cmd2"]})
+    # Test method for the python version raising an error
+    def test_get_python_version_raises_error(self, mock_file, mock_yaml_safe_load):
+        self._outcome.result.buffer = False
+        with self.assertRaises(ValueError) as context:
+            YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
+            self.assertEqual(str(context.exception), "Python version must be a string")
+       
+    
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.safe_load")
+    # Test method for the commands
     def test_get_commands(self, mock_yaml_safe_load, mock_file):
         mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
-        parser = YAMLInstallParser(file_dir="/some/directory")
+        parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
         commands = parser._get_commands()
         self.assertEqual(commands, ["cmd1", "cmd2"])
-
+    
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_yaml_install_parser.py
+++ b/tests/test_yaml_install_parser.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, mock_open
+import yaml
+from src.ersilia_pack.parsers import YAMLInstallParser  # Correct import
+
+class TestYAMLInstallParser(unittest.TestCase):
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    def test_get_python_version(self, mock_yaml_safe_load, mock_file):
+        mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
+        parser = YAMLInstallParser(file_dir="/some/directory")
+        python_version = parser._get_python_version()
+        self.assertEqual(python_version, "3.9")
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    def test_get_python_version_raises_error(self, mock_yaml_safe_load, mock_file):
+        # Mock YAML data with an invalid non-string Python version
+        mock_yaml_safe_load.return_value = {"python": 3.9, "commands": ["cmd1", "cmd2"]}
+        parser = YAMLInstallParser(file_dir="/some/directory")
+        with self.assertRaises(ValueError) as context:
+            parser._get_python_version()
+        self.assertEqual(str(context.exception), "Python version must be a string")
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    def test_get_commands(self, mock_yaml_safe_load, mock_file):
+        mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
+        parser = YAMLInstallParser(file_dir="/some/directory")
+        commands = parser._get_commands()
+        self.assertEqual(commands, ["cmd1", "cmd2"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yaml_install_parser.py
+++ b/tests/test_yaml_install_parser.py
@@ -1,38 +1,28 @@
-import unittest
+import pytest
 from unittest.mock import patch, mock_open
 import yaml
 from src.ersilia_pack.parsers import YAMLInstallParser
 
-class TestYAMLInstallParser(unittest.TestCase):
 
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("yaml.safe_load")
-    # Test method for the python version
-    def test_get_python_version(self, mock_yaml_safe_load, mock_file):
-        mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
-        parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
-        python_version = parser._get_python_version()
-        self.assertEqual(python_version, "3.9")
+# Case 1: Test method for the python version
+@patch("builtins.open", new_callable=mock_open, read_data='python: "3.9"')
+@patch("yaml.safe_load", return_value={"python": "3.9", "commands": ["cmd1", "cmd2"]})
+def test_get_python_version(mock_yaml_safe_load, mock_file):
+    parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
+    assert parser._get_python_version() == "3.9"
 
 
-    @patch("builtins.open", new_callable=mock_open, read_data="python: 3.9\ncommands:\n  - cmd1\n  - cmd2")
-    @patch("yaml.safe_load", return_value={"python": 3.9, "commands": ["cmd1", "cmd2"]})
-    # Test method for the python version raising an error
-    def test_get_python_version_raises_error(self, mock_file, mock_yaml_safe_load):
-        self._outcome.result.buffer = False
-        with self.assertRaises(ValueError) as context:
-            YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
-            self.assertEqual(str(context.exception), "Python version must be a string")
-       
+# Case 2: Test method for the python version raising an error
+@patch("builtins.open", new_callable=mock_open, read_data='python: "3.9"')
+@patch("yaml.safe_load", return_value={"python": 3.9, "commands": ["cmd1", "cmd2"]})
+def test_get_python_version_raises_error(mock_yaml_safe_load, mock_file):
+    with pytest.raises (ValueError, match="Python version must be a string"):
+        YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")       
+
     
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("yaml.safe_load")
-    # Test method for the commands
-    def test_get_commands(self, mock_yaml_safe_load, mock_file):
-        mock_yaml_safe_load.return_value = {"python": "3.9", "commands": ["cmd1", "cmd2"]}
-        parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
-        commands = parser._get_commands()
-        self.assertEqual(commands, ["cmd1", "cmd2"])
-    
-if __name__ == "__main__":
-    unittest.main()
+# Case 3: Test method for the commands    
+@patch("builtins.open", new_callable=mock_open, read_data='python: "3.9"')
+@patch("yaml.safe_load", return_value={"python": "3.9", "commands": ["cmd1", "cmd2"]})
+def test_get_commands(mock_yaml_safe_load, mock_file):
+    parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
+    assert parser._get_commands() == ["cmd1", "cmd2"]


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


**Description**
The task is to implement unit testing for the YAMLInstallParser Class in the parser module with different possible cases. The function of the class is to parse a YAML file that contains some installation details like the Python version and the list of commands.

**Changes to be made**
- [x] File Structure
          - Create a folder named "tests" in the same directory as "src".
          - Add an empty "__init.py__" file to the folder so it can be recognized as a package.
          - Create a Python file for the testing.
         
- [x] The following Test cases will be added to the unit test framework.
       - Case 1: Testing that the right python version is returned from the _get_python_version.
       - Case 2: Testing that a "**Value Error**" is raised if the Python version given is not a string.
       - Case 3: Testing that the correct list of commands is returned from the _get_commands.
       
- [x] Run the Unit test and provide the output.

**Status**

- [x] The Pytest framework in Python was used for the tests and the unittest.mock module was also used to mock the file system and other dependencies.
- [x] The test methods for the different cases were written.
- [x] The test was executed and all three cases passed as shown in the screenshot below.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/3a298fa9-632a-4aeb-afc4-2ca7c99a9917">


**To do**
- [ ] Pull request to be reviewed by mentors.

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #27 