### PR TITLE
Environment installation to stop on KeyboardInterrupt

### DIFF
--- a/src/ersilia_pack/packer.py
+++ b/src/ersilia_pack/packer.py
@@ -9,6 +9,7 @@ import yaml
 import urllib.request
 from .utils import logger
 from .parsers import YAMLInstallParser, DockerfileInstallParser, MetadataYml2JsonConverter
+import signal
 
 root = os.path.dirname(os.path.abspath(__file__))
 
@@ -16,6 +17,8 @@ class FastApiAppPacker(object):
     def __init__(self, repo_path, bundles_repo_path, conda_env_name=None):
         self.dest_dir = repo_path
         self.bundles_repo_path = bundles_repo_path
+        self.should_terminate = False
+        signal.signal(signal.SIGINT, self.signal_handller)
         if not os.path.exists(self.dest_dir):
             raise Exception("Model path {0} does not exist".format(self.dest_dir))
         self.model_id = self._get_model_id()
@@ -38,7 +41,9 @@ class FastApiAppPacker(object):
             self.install_writer = YAMLInstallParser(self.dest_dir, conda_env_name)
         else:
             raise Exception("No install file found") # TODO implement better exceptions
-
+    def signal_handler(self, signum, frame):
+        logger.info("Termination signal received, stopping the installation")
+        self.should_terminate = True
     def _get_model_id(self):
         json_file = os.path.join(self.dest_dir, "metadata.json")
         if os.path.exists(json_file):
@@ -188,8 +193,20 @@ class FastApiAppPacker(object):
 
     def _install_packages(self):
         cmd = f"bash {self.sh_file}"
-        subprocess.Popen(cmd, shell=True).wait()
+        process = subprocess.Popen(cmd, shell=True).wait()
 
+        while True:
+            if self.should_terminate:
+                process.terminate()
+                logger.info("Installation process terminated.")
+                break
+            else:
+                retcode = process.poll()
+                if retcode is not None:
+                    logger.info("installation completed successfully.")
+                else:
+                    logger.error(f"Installation failed with return code {retcode}")
+                break
     def _modify_python_exe(self):
         python_exe = self.install_writer.get_python_exe()
         with open(os.path.join(self.bundle_dir, "model", "framework", "run.sh"), "r") as f:

--- a/src/ersilia_pack/packer.py
+++ b/src/ersilia_pack/packer.py
@@ -18,7 +18,7 @@ class FastApiAppPacker(object):
         self.dest_dir = repo_path
         self.bundles_repo_path = bundles_repo_path
         self.should_terminate = False
-        signal.signal(signal.SIGINT, self.signal_handller)
+        signal.signal(signal.SIGINT, self.signal_handler)
         if not os.path.exists(self.dest_dir):
             raise Exception("Model path {0} does not exist".format(self.dest_dir))
         self.model_id = self._get_model_id()
@@ -198,7 +198,7 @@ class FastApiAppPacker(object):
         while True:
             if self.should_terminate:
                 process.terminate()
-                logger.info("Installation process terminated.")
+                logger.info("Installation process terminated by user.")
                 break
             else:
                 retcode = process.poll()


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed

[xx] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
[xx] Have you written new tests for your core changes, as applicable?
[xx] Have you successfully ran tests with your changes locally?



**Description**
This pull request addresses the issue where pressing CTRL + C does not terminate the environment installation process when using conda. Each conda installation starts a new process, leading to multiple processes running even after a keyboard interrupt. The solution implements a signal handler to properly catch the interrupt signal and terminate all running conda installation processes.

**Changes to be made**

Added a signal handler to capture SIGINT (keyboard interrupt) and set a flag to terminate ongoing installation processes.
Modified the _install_packages method to periodically check for this termination flag and  terminate all subprocesses when CTRL + C is pressed.
Included logging statements to inform the user when the installation process is terminated due to an interrupt.
Status
Ready for review

**To do**
Pull request to be reviewed by mentors.

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID
Related to issue ID: #9