### PR TITLE
Improve pip command validation for better dependency handling

### DIFF
--- a/src/ersilia_pack/parsers.py
+++ b/src/ersilia_pack/parsers.py
@@ -102,8 +102,31 @@ class YAMLInstallParser(InstallParser):
             raise ValueError("Python version must be a string")
         return self.data["python"]
     
+    @staticmethod
+    def _validate_pip_command(self, command):
+        if len(command) < 3 or command[0] != 'pip':
+            raise ValueError("Invalid pip command format. Must start with 'pip' and include a package.")
+        
+        if command[1] == "git":
+            if len(command) != 4:
+                raise ValueError("Invalid VCS pip command. Must specify 'git', URL, and commit SHA.")
+            return command
+        elif len(command) >= 3 and command[1] == "--index-url":
+            return command
+        elif len(command) == 3:
+            return command
+        else:
+            raise ValueError("Invalid pip command. Must include package and version or URL.")
+
     def _get_commands(self):
-        return self.data["commands"]
+        commands = self.data["commands"]
+        validated_commands = []
+        for command in commands:
+            if command[0] == 'pip':
+                validated_commands.append(self._validate_pip_command(command))
+            else:
+                validated_commands.append(command)
+        return validated_commands
 
 class DockerfileInstallParser(InstallParser):
     def __init__(self, file_dir, conda_env_name=None):

--- a/src/ersilia_pack/parsers.py
+++ b/src/ersilia_pack/parsers.py
@@ -103,20 +103,23 @@ class YAMLInstallParser(InstallParser):
         return self.data["python"]
     
     @staticmethod
-    def _validate_pip_command(self, command):
+    def _validate_pip_command(command):
         if len(command) < 3 or command[0] != 'pip':
             raise ValueError("Invalid pip command format. Must start with 'pip' and include a package.")
-        
+    
         if command[1] == "git":
             if len(command) != 4:
                 raise ValueError("Invalid VCS pip command. Must specify 'git', URL, and commit SHA.")
             return command
-        elif len(command) >= 3 and command[1] == "--index-url":
+        elif '--index-url' in command:
+            if len(command) < 5:
+                raise ValueError("Invalid pip command with --index-url. Must include package, version, and URL.")
             return command
         elif len(command) == 3:
             return command
         else:
             raise ValueError("Invalid pip command. Must include package and version or URL.")
+
 
     def _get_commands(self):
         commands = self.data["commands"]

--- a/tests/test_yaml_install_parser.py
+++ b/tests/test_yaml_install_parser.py
@@ -26,3 +26,51 @@ def test_get_python_version_raises_error(mock_yaml_safe_load, mock_file):
 def test_get_commands(mock_yaml_safe_load, mock_file):
     parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
     assert parser._get_commands() == ["cmd1", "cmd2"]
+    
+
+# Case 4:  Tests valid pip commands.
+@patch("builtins.open", new_callable=mock_open, read_data=""" 
+python: "3.9" 
+commands:
+  - ['pip', 'SomeProject', '1.3']
+  - ['pip', 'git', 'https://github.com/bp-kelley/descriptastorus.git', 'd552f934757378a61dd1799cdb589a864032cd1b']
+  - ['pip', 'torchvision', '0.17.1', '--index-url', 'https://download.pytorch.org/whl/cpu']
+""")
+@patch("yaml.safe_load", return_value={
+    "python": "3.9",
+    "commands": [
+        ['pip', 'SomeProject', '1.3'],
+        ['pip', 'git', 'https://github.com/bp-kelley/descriptastorus.git', 'd552f934757378a61dd1799cdb589a864032cd1b'],
+        ['pip', 'torchvision', '0.17.1', '--index-url', 'https://download.pytorch.org/whl/cpu']
+    ]
+})
+def test_get_commands_with_pip_dependencies(mock_yaml_safe_load, mock_file):
+    parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
+    commands = parser._get_commands()
+    assert commands == [
+        ['pip', 'SomeProject', '1.3'],
+        ['pip', 'git', 'https://github.com/bp-kelley/descriptastorus.git', 'd552f934757378a61dd1799cdb589a864032cd1b'],
+        ['pip', 'torchvision', '0.17.1', '--index-url', 'https://download.pytorch.org/whl/cpu']
+    ]
+
+# Case 5: Test Invalid pip commands
+@patch("builtins.open", new_callable=mock_open, read_data="""
+python: "3.9"
+commands:
+  - ['pip', 'SomeProject']  
+  - ['pip', 'git', 'https://github.com/bp-kelley/descriptastorus.git']
+  - ['pip', 'torchvision']  
+""")
+@patch("yaml.safe_load", return_value={
+    "python": "3.9",
+    "commands": [
+        ['pip', 'SomeProject'], 
+        ['pip', 'git', 'https://github.com/bp-kelley/descriptastorus.git'], 
+        ['pip', 'torchvision']  
+    ]
+})
+def test_get_commands_with_invalid_pip_dependencies(mock_yaml_safe_load, mock_file):
+    parser = YAMLInstallParser(file_dir="/workspaces/ersilia-pack/src/ersilia_pack/parsers.py")
+    with pytest.raises(ValueError, match="Invalid pip command format"):
+        parser._get_commands()
+


### PR DESCRIPTION
### Description

In this PR, I’ve added improvements to validating pip commands. The goal is to make sure that dependencies are specified correctly in the install.yml file, DockerFile and follow one of the expected formats:

- ['pip', 'SomeProject', '1.3'] (versioned dependency)

- ['pip', 'git', 'URL', 'commit_sha'] (VCS-based dependency)

- ['pip', 'torchvision', '0.17.1', '--index-url', 'URL'] (dependency with additional flags)

With these changes, we can ensure that dependencies are handled more consistently, reducing the risk of errors from malformed pip commands. If the commands don’t meet the expected formats, the parser will raise an error with a clear message, making it easier to identify and fix issues.