### PR TITLE
Add tests for MetadataYml2JsonConverter class

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,5 +6,5 @@
 from src.ersilia_pack.parsers.install_parser import InstallParser
 from src.ersilia_pack.parsers.dockerfile_install_parser import DockerfileInstallParser
 from src.ersilia_pack.parsers.yaml_install_parser import YAMLInstallParser
-
+from src.ersilia_pack.parsers.metadata_yml2json_converter import MetadataYml2JsonConverter
 

--- a/tests/fixtures/correct_metadata.yml
+++ b/tests/fixtures/correct_metadata.yml
@@ -1,0 +1,27 @@
+Identifier: model-001
+Slug: my-model
+Status: active
+Title: A Sample Model
+Description: This is a test model.
+Mode: classification
+Input: input.csv
+Input Shape: (100,)
+Task: 
+  - classification
+Output: 
+  - output.csv
+Output Type: 
+  - probability
+Output Shape: (100,)
+Interpretation: Interpretation text
+Tag: 
+  - test
+Publication: https://example.com/publication
+Source Code: https://github.com/example/repo
+License: MIT
+Contributor: John Doe
+S3: s3://example-bucket
+DockerHub: dockerhub/example-repo
+Docker Architecture: 
+  - amd64
+  - arm64

--- a/tests/fixtures/incorrect_metadata.yml
+++ b/tests/fixtures/incorrect_metadata.yml
@@ -1,0 +1,7 @@
+Identifier: model-001
+Slug: "example-slug"
+Title: ["Multiple", "Titles"]  # Invalid: Should be a string, not a list
+Description: "An example model."
+Mode: classification
+Input: "input.csv"
+Task: "classification"  # Invalid: Should be a list

--- a/tests/test_MetadataYml2JsonConverter.py
+++ b/tests/test_MetadataYml2JsonConverter.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+from src.ersilia_pack.parsers.metadata_yml2json_converter import MetadataYml2JsonConverter
+
+
+class TestMetadataYml2JsonConverter:
+    def test_correct_metadata_conversion(self):
+        yml_file = "tests/fixtures/correct_metadata.yml"
+        converter = MetadataYml2JsonConverter(yml_file)
+        result = converter.convert()
+
+        assert result["Identifier"] == "model-001"
+        assert result["Slug"] == "my-model"
+        assert result["Task"] == ["classification"]
+        assert result["Output"] == ["output.csv"]
+        assert result["Docker Architecture"] == ["amd64", "arm64"]
+
+    def test_incorrect_metadata_conversion(self):
+        yml_file = "tests/fixtures/incorrect_metadata.yml"
+        converter = MetadataYml2JsonConverter(yml_file)
+
+        with pytest.raises(Exception, match="Value is a list with more than one element"):
+            converter.convert()
+
+    def test_save_to_json_file(self, tmp_path):
+        yml_file = "tests/fixtures/correct_metadata.yml"
+        json_file = tmp_path / "output.json"
+        converter = MetadataYml2JsonConverter(yml_file, json_file)
+        converter.convert()
+
+        with open(json_file, "r") as f:
+            data = json.load(f)
+            assert data["Identifier"] == "model-001"
+            assert data["Slug"] == "my-model"


### PR DESCRIPTION
- [x]  Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**
The task involves creating a unit test for the `MetadataYml2JsonConverter` class, which converts a `metadata.yml` file into JSON format while ensuring the data adheres to specific type requirements.
The `MetadataYml2JsonConverter` Class Converts a `YAML` file (`metadata.yml`) to `JSON` format and ensures data in the file adheres to specific type restrictions. 

- It reads a metadata.yml file, processes the fields to ensure they meet specific type restrictions (e.g., list or string), and converts the data into JSON format.
- Supports saving the output directly to a JSON file.

Field Processing:

-` _tolist`: Converts a string to a list.
-` _tostr`: Converts a list with one element to a string. Raises an exception if the list has more than one element.

Fields Validation:

- Mandatory fields like Identifier, Slug, Task, etc., have specific processing rules.
- Optional fields like Status, Contributor, S3 are processed if present.

**The following Test Cases were Added:**
The following tests were implemented to  verify that the MetadataYml2JsonConverter works as expected. This includes testing:

1. Valid Input (`test_correct_metadata_conversion`):

- Check if all fields are converted correctly.
- Verify fields like `Task` are lists and `Slug` is a string.

2. Invalid Input (`test_incorrect_metadata_conversion`):

- Test for exceptions when input does not follow the expected types.
- For example, passing a list with more than one element to` _tostr`.

3. JSON File Save (test_save_to_json_file):

- Verify that the JSON file is created and contains the correct data.
**Testing locally**
I created two YAML files saved in fixtures folder in the test directory:

correct_metadata.yml: Contains valid data for all fields, adhering to type constraints.
incorrect_metadata.yml: Contains invalid data and ensure the incorrect_metadata.yml file includes all mandatory keys (Title, Description, etc.) but intentionally introduces errors in the values to test specific scenarios.
All tests passed 
[test_MetadataYml2JsonConverter_output1.txt](https://github.com/user-attachments/files/18251534/test_MetadataYml2JsonConverter_output1.txt)
Related to issue #28 and #25 
